### PR TITLE
relax semigroups constraint

### DIFF
--- a/comonad.cabal
+++ b/comonad.cabal
@@ -27,7 +27,7 @@ library
     base         >= 4       && < 5,
     transformers >= 0.2     && < 0.4,
     containers   >= 0.3     && < 0.6,
-    semigroups   >= 0.8.3   && < 0.8.4
+    semigroups   >= 0.8.3   && < 0.9
 
   exposed-modules:
     Control.Comonad


### PR DESCRIPTION
should this constraint be relaxed?
