### PR TITLE
Added flags for containers, contravariant and distributive

### DIFF
--- a/comonad.cabal
+++ b/comonad.cabal
@@ -30,6 +30,37 @@ flag test-doctests
   default: True
   manual: True
 
+flag containers
+  description:
+    You can disable the use of the `containers` package using `-f-containers`.
+    .
+    Disabing this is an unsupported configuration, but it may be useful for accelerating builds in sandboxes for expert users.
+  default: True
+  manual: True
+
+flag contravariant
+  description:
+    You can disable the use of the `contravariant` package using `-f-contravariant`.
+    .
+    Disabling this is an unsupported configuration, but it may be useful for accelerating builds in sandboxes for expert users.
+    .
+    If disabled we will not supply instances of `Contravariant`
+    .
+  default: True
+  manual: True
+
+flag distributive
+  description:
+    You can disable the use of the `distributive` package using `-f-distributive`.
+    .
+    Disabling this is an unsupported configuration, but it may be useful for accelerating builds in sandboxes for expert users.
+    .
+    If disabled we will not supply instances of `Distributive`
+    .
+  default: True
+  manual: True
+
+
 source-repository head
   type: git
   location: git://github.com/ekmett/comonad.git
@@ -42,12 +73,18 @@ library
 
   build-depends:
     base          >= 4       && < 5,
-    containers    >= 0.3     && < 0.6,
-    contravariant >= 0.2.0.1 && < 1,
-    distributive  >= 0.2.2   && < 1,
     semigroups    >= 0.8.3.1 && < 1,
     tagged        >= 0.1     && < 1,
     transformers  >= 0.2     && < 0.5
+
+  if flag(containers)
+    build-depends: containers >= 0.3 && < 0.6
+
+  if flag(contravariant)
+    build-depends: contravariant >= 0.2.0.1 && < 1 
+
+  if flag(distributive)
+    build-depends: distributive >= 0.2.2   && < 1 
 
   exposed-modules:
     Control.Comonad

--- a/src/Control/Comonad.hs
+++ b/src/Control/Comonad.hs
@@ -56,10 +56,13 @@ import Data.Functor.Identity
 import Data.List.NonEmpty hiding (map)
 import Data.Semigroup hiding (Product)
 import Data.Tagged
-import Data.Tree
 import Prelude hiding (id, (.))
 import Control.Monad.Fix
 import Data.Typeable
+
+#ifdef MIN_VERSION_containers
+import Data.Tree
+#endif
 
 infixl 4 <@, @>, <@@>, <@>, $>
 infixl 1 =>>
@@ -169,10 +172,12 @@ instance Comonad w => Comonad (IdentityT w) where
   extract = extract . runIdentityT
   {-# INLINE extract #-}
 
+#ifdef MIN_VERSION_containers
 instance Comonad Tree where
   duplicate w@(Node _ as) = Node w (map duplicate as)
   extract (Node a _) = a
   {-# INLINE extract #-}
+#endif
 
 instance Comonad NonEmpty where
   extend f w@ ~(_ :| aas) = f w :| case aas of
@@ -240,10 +245,12 @@ instance ComonadApply Identity where
 instance ComonadApply w => ComonadApply (IdentityT w) where
   IdentityT wa <@> IdentityT wb = IdentityT (wa <@> wb)
 
+#ifdef MIN_VERSION_containers
 instance ComonadApply Tree where
   (<@>) = (<*>)
   (<@ ) = (<* )
   ( @>) = ( *>)
+#endif
 
 -- | A suitable default definition for 'fmap' for a 'Comonad'.
 -- Promotes a function to a comonad.

--- a/src/Control/Comonad/Trans/Traced.hs
+++ b/src/Control/Comonad/Trans/Traced.hs
@@ -45,10 +45,13 @@ import Control.Monad (ap)
 import Control.Comonad
 import Control.Comonad.Hoist.Class
 import Control.Comonad.Trans.Class
-import Data.Distributive
 import Data.Functor.Identity
 import Data.Semigroup
 import Data.Typeable
+
+#ifdef MIN_VERSION_distributive
+import Data.Distributive
+#endif
 
 type Traced m = TracedT m Identity
 
@@ -80,8 +83,10 @@ instance Monoid m => ComonadTrans (TracedT m) where
 instance Monoid m => ComonadHoist (TracedT m) where
   cohoist l = TracedT . l . runTracedT
 
+#ifdef MIN_VERSION_distributive
 instance Distributive w => Distributive (TracedT m w) where
   distribute = TracedT . fmap (\tma m -> fmap ($ m) tma) . collect runTracedT
+#endif
 
 trace :: Comonad w => m -> TracedT m w a -> a
 trace m (TracedT wf) = extract wf m

--- a/src/Data/Functor/Coproduct.hs
+++ b/src/Data/Functor/Coproduct.hs
@@ -20,9 +20,12 @@ module Data.Functor.Coproduct
   ) where
 
 import Control.Comonad
-import Data.Functor.Contravariant
 import Data.Foldable
 import Data.Traversable
+
+#ifdef MIN_VERSION_contravariant
+import Data.Functor.Contravariant
+#endif
 
 newtype Coproduct f g a = Coproduct { getCoproduct :: Either (f a) (g a) }
   deriving (Eq, Ord, Read, Show)
@@ -53,5 +56,7 @@ instance (Comonad f, Comonad g) => Comonad (Coproduct f g) where
     (Right . extend (f . Coproduct . Right))
   extract = coproduct extract extract
 
+#ifdef MIN_VERSION_contravariant
 instance (Contravariant f, Contravariant g) => Contravariant (Coproduct f g) where
   contramap f = Coproduct . coproduct (Left . contramap f) (Right . contramap f)
+#endif


### PR DESCRIPTION
Hi,

Following the same logic adopted in the [semigroups package](https://hackage.haskell.org/package/semigroups), I've added flags for `containers`, `contravariant` and `distributive`.

Does it seem good with you?
Cheers
