### PR TITLE
ComonadTraced instance for (->) m

### DIFF
--- a/src/Control/Comonad/Traced/Class.hs
+++ b/src/Control/Comonad/Traced/Class.hs
@@ -39,6 +39,9 @@ traces f wa = trace (f (extract wa)) wa
 instance (Comonad w, Monoid m) => ComonadTraced m (Traced.TracedT m w) where
   trace = Traced.trace
 
+instance Monoid m => ComonadTraced m ((->) m) where
+  trace m f = f m
+
 lowerTrace :: (ComonadTrans t, ComonadTraced m w) => m -> t w a -> a
 lowerTrace m = trace m . lower
 {-# INLINE lowerTrace #-}


### PR DESCRIPTION
Since `Traced` is actually `(->)`, I think it makes sense to us.