### PR TITLE
Mark modules Safe rather than Trustworthy where possible.

### DIFF
--- a/src/Control/Comonad/Env.hs
+++ b/src/Control/Comonad/Env.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 -----------------------------------------------------------------------------
 -- |

--- a/src/Control/Comonad/Env/Class.hs
+++ b/src/Control/Comonad/Env/Class.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE CPP #-}
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 -----------------------------------------------------------------------------
 -- |

--- a/src/Control/Comonad/Identity.hs
+++ b/src/Control/Comonad/Identity.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 -----------------------------------------------------------------------------
 -- |

--- a/src/Control/Comonad/Store.hs
+++ b/src/Control/Comonad/Store.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 -----------------------------------------------------------------------------
 -- |

--- a/src/Control/Comonad/Store/Class.hs
+++ b/src/Control/Comonad/Store/Class.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE CPP #-}
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 -----------------------------------------------------------------------------
 -- |

--- a/src/Control/Comonad/Traced.hs
+++ b/src/Control/Comonad/Traced.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 -----------------------------------------------------------------------------
 -- |

--- a/src/Control/Comonad/Traced/Class.hs
+++ b/src/Control/Comonad/Traced/Class.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE CPP #-}
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 -----------------------------------------------------------------------------
 -- |

--- a/src/Control/Comonad/Trans/Class.hs
+++ b/src/Control/Comonad/Trans/Class.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 -----------------------------------------------------------------------------
 -- |

--- a/src/Control/Comonad/Trans/Env.hs
+++ b/src/Control/Comonad/Trans/Env.hs
@@ -1,9 +1,8 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 #if __GLASGOW_HASKELL__ >= 707
-{-# LANGUAGE StandaloneDeriving, DeriveDataTypeable #-}
-#endif
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE StandaloneDeriving, DeriveDataTypeable, Safe #-}
+#elif __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/src/Control/Comonad/Trans/Store.hs
+++ b/src/Control/Comonad/Trans/Store.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__ >= 707
-{-# LANGUAGE StandaloneDeriving, DeriveDataTypeable #-}
-#endif
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE StandaloneDeriving, DeriveDataTypeable, Safe #-}
+#elif __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/src/Control/Comonad/Trans/Traced.hs
+++ b/src/Control/Comonad/Trans/Traced.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__ >= 707
-{-# LANGUAGE StandaloneDeriving, DeriveDataTypeable #-}
-#endif
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE StandaloneDeriving, DeriveDataTypeable, Safe #-}
+#elif __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/src/Data/Functor/Coproduct.hs
+++ b/src/Data/Functor/Coproduct.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 -----------------------------------------------------------------------------
 -- |


### PR DESCRIPTION
It turns out that for ghc >= 7.8, all modules can be marked safe, so in principle the package does not have to be trusted to be used safely.

Note that I have only tested ghc 7.6.3, 7.8.3 and 7.10.1.