### PR TITLE
SafeHaskell-related GHC 7.2 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ install:
 script:
  - cabal configure -v2 --enable-tests
  - cabal build
+ - cabal test --show-details=always
  - cabal check
  - cabal sdist
  - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,15 @@
 env:
- - GHCVER=7.0.1 CABALVER=1.16
- - GHCVER=7.0.4 CABALVER=1.16
- - GHCVER=7.2.2 CABALVER=1.16
- - GHCVER=7.4.2 CABALVER=1.16
- - GHCVER=7.6.3 CABALVER=1.16
+ - GHCVER=7.0.1 CABALVER=1.18
+ - GHCVER=7.0.4 CABALVER=1.18
+ - GHCVER=7.2.2 CABALVER=1.18
+ - GHCVER=7.4.2 CABALVER=1.18
+ - GHCVER=7.6.3 CABALVER=1.18
  - GHCVER=7.8.4 CABALVER=1.18
  - GHCVER=7.10.1 CABALVER=1.22
  - GHCVER=head CABALVER=1.22
 
 matrix:
   allow_failures:
-   - env: GHCVER=7.0.1 CABALVER=1.16
-   - env: GHCVER=7.0.4 CABALVER=1.16
-   - env: GHCVER=7.2.2 CABALVER=1.16
    - env: GHCVER=head CABALVER=1.22
 
 before_install:
@@ -29,6 +26,7 @@ install:
 script:
  - cabal configure -v2 --enable-tests
  - cabal build
+ - cabal check
  - cabal sdist
  - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
    cd dist/;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 env:
- - GHCVER=7.0.1 CABALVER=1.18
  - GHCVER=7.0.4 CABALVER=1.18
  - GHCVER=7.2.2 CABALVER=1.18
  - GHCVER=7.4.2 CABALVER=1.18
@@ -21,8 +20,7 @@ before_install:
 
 install:
  - travis_retry cabal update
- - ghc-pkg expose binary # It's hidden on old GHCs, for some reason
- - cabal install Cabal # Workaround for https://github.com/haskell/cabal/issues/1666
+ - cabal install binary Cabal # Workaround for https://github.com/haskell/cabal/issues/1666
  - cabal install --enable-tests --only-dependencies
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
 
 install:
  - travis_retry cabal update
+ - ghc-pkg expose binary # It's hidden on old GHCs, for some reason
  - cabal install Cabal # Workaround for https://github.com/haskell/cabal/issues/1666
  - cabal install --enable-tests --only-dependencies
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,12 @@ before_install:
 
 install:
  - travis_retry cabal update
+ - cabal install Cabal # Workaround for https://github.com/haskell/cabal/issues/1666
  - cabal install --enable-tests --only-dependencies
 
 script:
  - cabal configure -v2 --enable-tests
  - cabal build
- - cabal test --show-details=always
  - cabal check
  - cabal sdist
  - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;

--- a/comonad.cabal
+++ b/comonad.cabal
@@ -118,6 +118,7 @@ test-suite doctests
   type:           exitcode-stdio-1.0
   default-language: Haskell2010
   main-is:        doctests.hs
+  other-modules:  Build_doctests
   ghc-options:    -Wall -threaded
   hs-source-dirs: tests
 

--- a/comonad.cabal
+++ b/comonad.cabal
@@ -118,7 +118,6 @@ test-suite doctests
   type:           exitcode-stdio-1.0
   default-language: Haskell2010
   main-is:        doctests.hs
-  other-modules:  Build_doctests
   ghc-options:    -Wall -threaded
   hs-source-dirs: tests
 

--- a/src/Control/Comonad/Env.hs
+++ b/src/Control/Comonad/Env.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE CPP #-}
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 704
+#if MIN_VERSION_transformers(0,3,0)
 {-# LANGUAGE Safe #-}
+#else
+{-# LANGUAGE Trustworthy #-}
+#endif
 #endif
 -----------------------------------------------------------------------------
 -- |

--- a/src/Control/Comonad/Env/Class.hs
+++ b/src/Control/Comonad/Env/Class.hs
@@ -3,8 +3,12 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE CPP #-}
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 704
+#if MIN_VERSION_transformers(0,3,0)
 {-# LANGUAGE Safe #-}
+#else
+{-# LANGUAGE Trustworthy #-}
+#endif
 #endif
 -----------------------------------------------------------------------------
 -- |

--- a/src/Control/Comonad/Identity.hs
+++ b/src/Control/Comonad/Identity.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE CPP #-}
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 704
+#if MIN_VERSION_transformers(0,3,0)
 {-# LANGUAGE Safe #-}
+#else
+{-# LANGUAGE Trustworthy #-}
+#endif
 #endif
 -----------------------------------------------------------------------------
 -- |

--- a/src/Control/Comonad/Store.hs
+++ b/src/Control/Comonad/Store.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE CPP #-}
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 704
+#if MIN_VERSION_transformers(0,3,0)
 {-# LANGUAGE Safe #-}
+#else
+{-# LANGUAGE Trustworthy #-}
+#endif
 #endif
 -----------------------------------------------------------------------------
 -- |

--- a/src/Control/Comonad/Store/Class.hs
+++ b/src/Control/Comonad/Store/Class.hs
@@ -3,8 +3,12 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE CPP #-}
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 704
+#if MIN_VERSION_transformers(0,3,0)
 {-# LANGUAGE Safe #-}
+#else
+{-# LANGUAGE Trustworthy #-}
+#endif
 #endif
 -----------------------------------------------------------------------------
 -- |

--- a/src/Control/Comonad/Traced.hs
+++ b/src/Control/Comonad/Traced.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE CPP #-}
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 704
+#if MIN_VERSION_transformers(0,3,0)
 {-# LANGUAGE Safe #-}
+#else
+{-# LANGUAGE Trustworthy #-}
+#endif
 #endif
 -----------------------------------------------------------------------------
 -- |

--- a/src/Control/Comonad/Traced/Class.hs
+++ b/src/Control/Comonad/Traced/Class.hs
@@ -3,8 +3,12 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE CPP #-}
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 704
+#if MIN_VERSION_transformers(0,3,0)
 {-# LANGUAGE Safe #-}
+#else
+{-# LANGUAGE Trustworthy #-}
+#endif
 #endif
 -----------------------------------------------------------------------------
 -- |

--- a/src/Control/Comonad/Trans/Class.hs
+++ b/src/Control/Comonad/Trans/Class.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE CPP #-}
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 704
+#if MIN_VERSION_transformers(0,3,0)
 {-# LANGUAGE Safe #-}
+#else
+{-# LANGUAGE Trustworthy #-}
+#endif
 #endif
 -----------------------------------------------------------------------------
 -- |

--- a/src/Data/Functor/Coproduct.hs
+++ b/src/Data/Functor/Coproduct.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE CPP #-}
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 704
+#if MIN_VERSION_transformers(0,3,0) && MIN_VERSION_tagged(0,6,1)
 {-# LANGUAGE Safe #-}
+#else
+{-# LANGUAGE Trustworthy #-}
+#endif
 #endif
 -----------------------------------------------------------------------------
 -- |


### PR DESCRIPTION
GHC 7.2 can't infer that modules from `tranformers` are `Safe`, so until [this issue](http://hub.darcs.net/ross/transformers/issue/3) is resolved, I added a workaround where all modules in `comonad` that import `Data.Functor.Identity` should be marked as `Trustworthy` on GHC 7.2 (a similar workaround is employed for the module that imports `Data.Functor.Contravariant`).