### PR TITLE
Default implementation for peek + adjusted minimal complete definition pragma

### DIFF
--- a/src/Control/Comonad/Store/Class.hs
+++ b/src/Control/Comonad/Store/Class.hs
@@ -32,7 +32,9 @@ import Data.Semigroup
 
 class Comonad w => ComonadStore s w | w -> s where
   pos :: w a -> s
+
   peek :: s -> w a -> a
+  peek = peeks . const
 
   peeks :: (s -> s) -> w a -> a
   peeks f w = peek (f (pos w)) w
@@ -45,6 +47,10 @@ class Comonad w => ComonadStore s w | w -> s where
 
   experiment :: Functor f => (s -> f s) -> w a -> f a
   experiment f w = fmap (`peek` w) (f (pos w))
+
+#if __GLASGOW_HASKELL__ >= 708
+  {-# MINIMAL pos, (peek | peeks) #-}
+#endif
 
 instance Comonad w => ComonadStore s (Store.StoreT s w) where
   pos = Store.pos


### PR DESCRIPTION
Probably not a big deal, but here it is if you wanted it.  It's likely you already had a reason to not have it, though :)