### PR TITLE
Fixing redundant import warnings in a backwards-compatible manner

### DIFF
--- a/src/Control/Comonad/Store/Class.hs
+++ b/src/Control/Comonad/Store/Class.hs
@@ -29,6 +29,7 @@ import qualified Control.Comonad.Trans.Store as Store
 import Control.Comonad.Trans.Traced
 import Control.Comonad.Trans.Identity
 import Data.Semigroup
+import Prelude
 
 class Comonad w => ComonadStore s w | w -> s where
   pos :: w a -> s

--- a/src/Control/Comonad/Traced/Class.hs
+++ b/src/Control/Comonad/Traced/Class.hs
@@ -28,6 +28,7 @@ import Control.Comonad.Trans.Store
 import qualified Control.Comonad.Trans.Traced as Traced
 import Control.Comonad.Trans.Identity
 import Data.Semigroup
+import Prelude
 
 class Comonad w => ComonadTraced m w | w -> m where
   trace :: m -> w a -> a

--- a/src/Control/Comonad/Trans/Env.hs
+++ b/src/Control/Comonad/Trans/Env.hs
@@ -66,6 +66,7 @@ import Data.Foldable
 import Data.Traversable
 import Data.Functor.Identity
 import Data.Semigroup
+import Prelude
 
 #ifdef __GLASGOW_HASKELL__
 #if __GLASGOW_HASKELL__ >= 707

--- a/src/Control/Comonad/Trans/Store.hs
+++ b/src/Control/Comonad/Trans/Store.hs
@@ -81,6 +81,7 @@ import Control.Comonad.Hoist.Class
 import Control.Comonad.Trans.Class
 import Data.Functor.Identity
 import Data.Semigroup
+import Prelude
 
 #ifdef __GLASGOW_HASKELL__
 import Data.Typeable

--- a/src/Control/Comonad/Trans/Traced.hs
+++ b/src/Control/Comonad/Trans/Traced.hs
@@ -47,6 +47,7 @@ import Control.Comonad.Trans.Class
 import Data.Functor.Identity
 import Data.Semigroup
 import Data.Typeable
+import Prelude
 
 #ifdef MIN_VERSION_distributive
 import Data.Distributive

--- a/src/Data/Functor/Coproduct.hs
+++ b/src/Data/Functor/Coproduct.hs
@@ -22,6 +22,7 @@ module Data.Functor.Coproduct
 import Control.Comonad
 import Data.Foldable
 import Data.Traversable
+import Prelude
 
 #ifdef MIN_VERSION_contravariant
 import Data.Functor.Contravariant


### PR DESCRIPTION
In case you wanted it :)  It uses the method suggested in the [official migration guide][guide], which may or may not be the cleanest.  But it's the least CPPish.

Tested from 7.6.3.

[guide]: https://ghc.haskell.org/trac/ghc/wiki/Migration/7.10