### PR TITLE
Bump bound to `tagged >= 0.7`

### DIFF
--- a/comonad.cabal
+++ b/comonad.cabal
@@ -81,7 +81,7 @@ library
   build-depends:
     base                >= 4       && < 5,
     semigroups          >= 0.8.3.1 && < 1,
-    tagged              >= 0.1     && < 1,
+    tagged              >= 0.7     && < 1,
     transformers        >= 0.2     && < 0.6,
     transformers-compat >= 0.3     && < 1
 


### PR DESCRIPTION
Solves the second part of #41 
 
*EDIT* flaky travis