### PR TITLE
Add `Comonad` instances for `Tagged s` with `s` of any kind

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+next
+----
+* Add `Comonad` instances for `Tagged s` with `s` of any kind. Before the
+  change, `s` had to be of kind `*`.
+
 5.0.3 [2018.02.06]
 ------------------
 * Don't enable `Safe` on GHC 7.2.

--- a/src/Control/Comonad.hs
+++ b/src/Control/Comonad.hs
@@ -4,6 +4,9 @@
 #elif __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy, DefaultSignatures #-}
 #endif
+#if __GLASGOW_HASKELL__ >= 706
+{-# LANGUAGE PolyKinds #-}
+#endif
  -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Comonad
@@ -176,6 +179,14 @@ instance Comonad Identity where
   extract = runIdentity
   {-# INLINE extract #-}
 
+#if __GLASGOW_HASKELL__ >= 706
+-- $
+-- The variable `s` can have any kind.
+-- For example, here it has kind `Bool`:
+-- >>> :set -XDataKinds
+-- >>> extract (Tagged 42 :: Tagged 'True Integer)
+-- 42
+#endif
 instance Comonad (Tagged s) where
   duplicate = Tagged
   {-# INLINE duplicate #-}


### PR DESCRIPTION
Before the change, `s` had to be of kind `*`.

The new instances are obtained by enabling the `PolyKinds` extension in the
`Control.Comonad` module.