### PR TITLE
Bump min semigroups version and make it conditional

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,7 @@
 Next
 ----
-* Raised the minimum `semigroups` version to 0.16.2.
+* Raised the minimum `semigroups` version to 0.16.2. In addition, the
+  package will only be required at all for GHCs before 8.0.
 
 5.0.4 [2018.07.01]
 ------------------

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+Next
+----
+* Raised the minimum `semigroups` version to 0.16.2.
+
 5.0.4 [2018.07.01]
 ------------------
 * Add `Comonad` instances for `Tagged s` with `s` of any kind. Before the

--- a/comonad.cabal
+++ b/comonad.cabal
@@ -79,11 +79,13 @@ library
   ghc-options: -Wall
 
   build-depends:
-    base                >= 4       && < 5,
-    semigroups          >= 0.16.2  && < 1,
-    tagged              >= 0.7     && < 1,
-    transformers        >= 0.2     && < 0.6,
-    transformers-compat >= 0.3     && < 1
+    base                >= 4   && < 5,
+    tagged              >= 0.7 && < 1,
+    transformers        >= 0.2 && < 0.6,
+    transformers-compat >= 0.3 && < 1
+
+  if !impl(ghc >= 8.0)
+    build-depends: semigroups >= 0.16.2 && < 1
 
   if flag(containers)
     build-depends: containers >= 0.3 && < 0.7

--- a/comonad.cabal
+++ b/comonad.cabal
@@ -80,7 +80,7 @@ library
 
   build-depends:
     base                >= 4       && < 5,
-    semigroups          >= 0.8.3.1 && < 1,
+    semigroups          >= 0.16.2  && < 1,
     tagged              >= 0.7     && < 1,
     transformers        >= 0.2     && < 0.6,
     transformers-compat >= 0.3     && < 1

--- a/src/Control/Comonad.hs
+++ b/src/Control/Comonad.hs
@@ -157,7 +157,6 @@ instance Comonad ((,)e) where
   extract = snd
   {-# INLINE extract #-}
 
-#if MIN_VERSION_semigroups(0,16,2)
 instance Comonad (Arg e) where
   duplicate w@(Arg a _) = Arg a w
   {-# INLINE duplicate #-}
@@ -165,7 +164,6 @@ instance Comonad (Arg e) where
   {-# INLINE extend #-}
   extract (Arg _ b) = b
   {-# INLINE extract #-}
-#endif
 
 instance Monoid m => Comonad ((->)m) where
   duplicate f m = f . mappend m

--- a/src/Control/Comonad/Env/Class.hs
+++ b/src/Control/Comonad/Env/Class.hs
@@ -44,10 +44,8 @@ instance Comonad w => ComonadEnv e (Env.EnvT e w) where
 instance ComonadEnv e ((,)e) where
   ask = fst
 
-#if MIN_VERSION_semigroups(0,16,2)
 instance ComonadEnv e (Arg e) where
   ask (Arg e _) = e
-#endif
 
 lowerAsk :: (ComonadEnv e w, ComonadTrans t) => t w a -> e
 lowerAsk = ask . lower


### PR DESCRIPTION
Bumping the minimum version to 0.16.2 reduces the need for CPP, and lets us make it a conditional dependency without a real rat's nest of CPP checking for a disjunction of `base` and `semigroup` versions.