### PR TITLE
 No whitespace after the '@' in as-patterns

### DIFF
--- a/src/Control/Comonad.hs
+++ b/src/Control/Comonad.hs
@@ -204,7 +204,8 @@ instance Comonad Tree where
 #endif
 
 instance Comonad NonEmpty where
-  extend f w@ ~(_ :| aas) = f w :| case aas of
+  extend f w@(~(_ :| aas)) =
+    f w :| case aas of
       []     -> []
       (a:as) -> toList (extend f (a :| as))
   extract ~(a :| _) = a


### PR DESCRIPTION
Forward-compatibility for [GHC Proposal 229](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0229-whitespace-bang-patterns.rst)