### PR TITLE
Mark modules as explicitly safe

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+next [202y.mm.dd]
+-----------------
+* Explicitly mark modules as Safe or Trustworthy
+
 5.0.7 [2020.12.15]
 ------------------
 * Move `FunctorWithIndex (TracedT m w)` instance from `lens`.

--- a/comonad.cabal
+++ b/comonad.cabal
@@ -89,21 +89,26 @@ library
 
   build-depends:
     base                >= 4   && < 5,
-    tagged              >= 0.7 && < 1,
-    transformers        >= 0.2 && < 0.6,
-    transformers-compat >= 0.3 && < 1
+    tagged              >= 0.8.6.1 && < 1,
+    transformers        >= 0.3 && < 0.6,
+    transformers-compat >= 0.5 && < 1
 
   if !impl(ghc >= 8.0)
-    build-depends: semigroups >= 0.16.2 && < 1
+    build-depends: semigroups >= 0.18.5 && < 1
 
   if flag(containers)
     build-depends: containers >= 0.3 && < 0.7
 
   if flag(distributive)
-    build-depends: distributive >= 0.2.2   && < 1
+    build-depends: distributive >= 0.5.2 && < 1
 
   if flag(indexed-traversable)
-    build-depends: indexed-traversable >= 0.1 && < 0.2
+    build-depends: indexed-traversable >= 0.1.1 && < 0.2
+
+  if impl(ghc >= 9.0)
+    -- these flags may abort compilation with GHC-8.10
+    -- https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3295
+    ghc-options: -Winferred-safe-imports -Wmissing-safe-haskell-mode
 
   exposed-modules:
     Control.Comonad

--- a/src/Control/Comonad/Hoist/Class.hs
+++ b/src/Control/Comonad/Hoist/Class.hs
@@ -1,4 +1,10 @@
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Comonad.Hoist.Class

--- a/src/Data/Functor/Composition.hs
+++ b/src/Data/Functor/Composition.hs
@@ -1,3 +1,9 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
 module Data.Functor.Composition
   ( Composition(..) ) where
 


### PR DESCRIPTION
Bump lower bounds to known explictly safe versions.

(Note: let's not release this before we make `build-type: Simple` change as well).

This PR is part of https://github.com/ekmett/lens/issues/959 effort