### PR TITLE
Support MicroHs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 dist
-dist-newstyle
+dist-*
 docs
 wiki
 TAGS

--- a/comonad.cabal
+++ b/comonad.cabal
@@ -69,7 +69,7 @@ flag indexed-traversable
 
 source-repository head
   type: git
-  location: git://github.com/ekmett/comonad.git
+  location: https://github.com/ekmett/comonad.git
 
 library
   hs-source-dirs: src

--- a/examples/History.hs
+++ b/examples/History.hs
@@ -52,7 +52,7 @@ ini :: History a -> a
 ini dx = extract dx `fby` extend ini dx
 
 fibo :: Num b => History a -> b
-fibo d = wfix $ d $> fby 0 . extend (\dfibo -> extract dfibo + fby 1 dfibo) 
+fibo d = wfix $ d $> fby 0 . extend (\dfibo -> extract dfibo + fby 1 dfibo)
 
 fibo' :: Num b => History a -> b
 fibo' d = fst $ wfix $ d $> fby (0, 1) . fmap (\(x, x') -> (x',x+x'))

--- a/examples/comonad-examples.cabal
+++ b/examples/comonad-examples.cabal
@@ -30,7 +30,7 @@ tested-with:   GHC == 8.0.2
 
 source-repository head
   type: git
-  location: git://github.com/ekmett/comonad.git
+  location: https://github.com/ekmett/comonad.git
 
 library
   hs-source-dirs: .

--- a/src/Control/Comonad/Trans/Env.hs
+++ b/src/Control/Comonad/Trans/Env.hs
@@ -65,6 +65,11 @@ import Data.Functor.Identity
 import Data.Semigroup
 #endif
 
+#ifdef __MHS__
+import Data.Foldable
+import Data.Traversable
+#endif
+
 -- $setup
 -- >>> import Control.Comonad
 


### PR DESCRIPTION
MicroHs doesn't export `Foldable` and `Traversable` from the `Prelude`, so they have to be imported explicitly. Also update the git links.